### PR TITLE
Update tests

### DIFF
--- a/tests/statsd_test.py
+++ b/tests/statsd_test.py
@@ -3,7 +3,7 @@ import random
 import re
 import socket
 from datetime import timedelta
-from unittest import SkipTest, mock
+from unittest import mock
 
 import pytest
 
@@ -202,7 +202,6 @@ def _test_resolution(cl, proto, addr):
 
 
 def test_ipv6_resolution_udp():
-    raise SkipTest("IPv6 resolution is broken on Travis")
     cl = _udp_client(addr="localhost", ipv6=True)
     _test_resolution(cl, "udp", ("::1", 8125, 0, 0))
 

--- a/tests/statsd_test.py
+++ b/tests/statsd_test.py
@@ -254,21 +254,21 @@ def test_gauge_delta_tcp():
 
 def _test_gauge_absolute_negative(cl, proto):
     cl.gauge("foo", -5, delta=False)
-    _sock_check(cl._sock, 1, "foo:0|g\nfoo:-5|g")
+    _sock_check(cl._sock, 1, proto, "foo:0|g\nfoo:-5|g")
 
 
 @mock.patch.object(random, "random", lambda: -1)
 def test_gauge_absolute_negative_udp():
     """StatsClient.gauge works with absolute negative value."""
     cl = _udp_client()
-    _test_gauge_delta(cl, "udp")
+    _test_gauge_absolute_negative(cl, "udp")
 
 
 @mock.patch.object(random, "random", lambda: -1)
 def test_gauge_absolute_negative_tcp():
     """TCPStatsClient.gauge works with absolute negative value."""
     cl = _tcp_client()
-    _test_gauge_delta(cl, "tcp")
+    _test_gauge_absolute_negative(cl, "tcp")
 
 
 def _test_gauge_absolute_negative_rate(cl, proto, mock_random):


### PR DESCRIPTION
- Replace custom `assert_raises`

    Replace this with the same named function from `pytest`

- Avoid skipping test

    I want to see if this passes in CI. If it doesn't I might just ignore it
    while in CI runs.

- Fix missing tests

    Coverage showed `_test_gauge_absolute_negative` was never being run.
    There were some tests around that were named as if they should be
    calling this and were just testing behaviour covered in other tests so I
    assume they were accidentally calling the wrong function.

- Add tests to cover close and reconnect behaviour

    Just covering some behaviour shown to be missing by coverage.