### PR TITLE
Add `mypy`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,7 @@ jobs:
       - run: flake8 statsd
       - run: black --check --diff statsd tests
       - run: isort --check-only --diff statsd tests
+      - run: mypy --show-error-codes statsd tests
 
 workflows:
   test-pythons:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ flake8>=4.0
 pytest>=6.2.5
 black ~= 22.0
 isort ~= 5.10
+mypy <= 1.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,12 @@ ignore =
 
 [isort]
 profile = black
+
+[mypy]
+strict = True
+
+[mypy-tests.*]
+disallow_untyped_calls = False
+disallow_untyped_defs = False
+warn_return_any = False
+strict_equality = False

--- a/statsd/client/__init__.py
+++ b/statsd/client/__init__.py
@@ -1,2 +1,4 @@
-from .stream import TCPStatsClient, UnixSocketStatsClient  # noqa
-from .udp import StatsClient  # noqa
+from .stream import TCPStatsClient, UnixSocketStatsClient
+from .udp import StatsClient
+
+__all__ = ["TCPStatsClient", "UnixSocketStatsClient", "StatsClient"]

--- a/statsd/client/base.py
+++ b/statsd/client/base.py
@@ -1,27 +1,35 @@
+from __future__ import annotations
+
 import random
 from collections import deque
 from datetime import timedelta
+from types import TracebackType
+from typing import Deque, TypeVar
 
 from .timer import Timer
+
+PipelineT = TypeVar("PipelineT", bound="PipelineBase")
 
 
 class StatsClientBase:
     """A Base class for various statsd clients."""
 
-    def close(self):
+    _prefix: str | None
+
+    def close(self) -> None:
         """Used to close and clean up any underlying resources."""
         raise NotImplementedError()
 
-    def _send(self):
+    def _send(self, data: str | None) -> None:
         raise NotImplementedError()
 
-    def pipeline(self):
+    def pipeline(self) -> PipelineBase:
         raise NotImplementedError()
 
-    def timer(self, stat, rate=1):
+    def timer(self, stat: str, rate: float = 1) -> Timer:
         return Timer(self, stat, rate)
 
-    def timing(self, stat, delta, rate=1):
+    def timing(self, stat: str, delta: float | timedelta, rate: float = 1) -> None:
         """
         Send new timing information.
 
@@ -32,15 +40,17 @@ class StatsClientBase:
             delta = delta.total_seconds() * 1000.0
         self._send_stat(stat, "%0.6f|ms" % delta, rate)
 
-    def incr(self, stat, count=1, rate=1):
+    def incr(self, stat: str, count: int = 1, rate: float = 1) -> None:
         """Increment a stat by `count`."""
         self._send_stat(stat, "%s|c" % count, rate)
 
-    def decr(self, stat, count=1, rate=1):
+    def decr(self, stat: str, count: int = 1, rate: float = 1) -> None:
         """Decrement a stat by `count`."""
         self.incr(stat, -count, rate)
 
-    def gauge(self, stat, value, rate=1, delta=False):
+    def gauge(
+        self, stat: str, value: float, rate: float = 1, delta: bool = False
+    ) -> None:
         """Set a gauge value."""
         if value < 0 and not delta:
             if rate < 1:
@@ -53,17 +63,17 @@ class StatsClientBase:
             prefix = "+" if delta and value >= 0 else ""
             self._send_stat(stat, f"{prefix}{value}|g", rate)
 
-    def set(self, stat, value, rate=1):
+    def set(self, stat: str, value: float | str, rate: float = 1) -> None:
         """Set a set value."""
         self._send_stat(stat, "%s|s" % value, rate)
 
-    def _send_stat(self, stat, value, rate):
+    def _send_stat(self, stat: str, value: float | str, rate: float) -> None:
         self._after(self._prepare(stat, value, rate))
 
-    def _prepare(self, stat, value, rate):
+    def _prepare(self, stat: str, value: float | str, rate: float) -> str | None:
         if rate < 1:
             if random.random() > rate:
-                return
+                return None
             value = f"{value}|@{rate}"
 
         if self._prefix:
@@ -71,34 +81,39 @@ class StatsClientBase:
 
         return f"{stat}:{value}"
 
-    def _after(self, data):
+    def _after(self, data: str | None) -> None:
         if data:
             self._send(data)
 
 
 class PipelineBase(StatsClientBase):
-    def __init__(self, client):
+    def __init__(self, client: StatsClientBase):
         self._client = client
         self._prefix = client._prefix
-        self._stats = deque()
+        self._stats: Deque[str] = deque()
 
-    def _send(self):
-        raise NotImplementedError()
+    def _send(self, data: str | None = None) -> None:
+        super()._send(data)
 
-    def _after(self, data):
+    def _after(self, data: str | None) -> None:
         if data is not None:
             self._stats.append(data)
 
-    def __enter__(self):
+    def __enter__(self) -> PipelineBase:
         return self
 
-    def __exit__(self, typ, value, tb):
+    def __exit__(
+        self,
+        typ: type[BaseException] | None,
+        value: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
         self.send()
 
-    def send(self):
+    def send(self) -> None:
         if not self._stats:
             return
         self._send()
 
-    def pipeline(self):
+    def pipeline(self: PipelineT) -> PipelineT:
         return self.__class__(self)

--- a/statsd/client/stream.py
+++ b/statsd/client/stream.py
@@ -1,46 +1,58 @@
+from __future__ import annotations
+
 import socket
 
 from .base import PipelineBase, StatsClientBase
 
 
 class StreamPipeline(PipelineBase):
-    def _send(self):
+    def _send(self, data: str | None = None) -> None:
         self._client._after("\n".join(self._stats))
         self._stats.clear()
 
 
 class StreamClientBase(StatsClientBase):
-    def connect(self):
+    _sock: socket.socket | None
+
+    def connect(self) -> None:
         raise NotImplementedError()
 
-    def close(self):
+    def close(self) -> None:
         if self._sock and hasattr(self._sock, "close"):
             self._sock.close()
         self._sock = None
 
-    def reconnect(self):
+    def reconnect(self) -> None:
         self.close()
         self.connect()
 
-    def pipeline(self):
+    def pipeline(self) -> StreamPipeline:
         return StreamPipeline(self)
 
-    def _send(self, data):
+    def _send(self, data: str | None) -> None:
         """Send data to statsd."""
         if not self._sock:
             self.connect()
         self._do_send(data)
 
-    def _do_send(self, data):
-        self._sock.sendall(data.encode("ascii") + b"\n")
+    def _do_send(self, data: str | None) -> None:
+        if self._sock is None:
+            raise RuntimeError("Trying to send to closed socket")
+        if data is not None:
+            self._sock.sendall(data.encode("ascii") + b"\n")
 
 
 class TCPStatsClient(StreamClientBase):
     """TCP version of StatsClient."""
 
     def __init__(
-        self, host="localhost", port=8125, prefix=None, timeout=None, ipv6=False
-    ):
+        self,
+        host: str = "localhost",
+        port: int = 8125,
+        prefix: str | None = None,
+        timeout: float | None = None,
+        ipv6: bool = False,
+    ) -> None:
         """Create a new client."""
         self._host = host
         self._port = port
@@ -49,7 +61,7 @@ class TCPStatsClient(StreamClientBase):
         self._prefix = prefix
         self._sock = None
 
-    def connect(self):
+    def connect(self) -> None:
         fam = socket.AF_INET6 if self._ipv6 else socket.AF_INET
         family, _, _, _, addr = socket.getaddrinfo(
             self._host, self._port, fam, socket.SOCK_STREAM
@@ -62,14 +74,16 @@ class TCPStatsClient(StreamClientBase):
 class UnixSocketStatsClient(StreamClientBase):
     """Unix domain socket version of StatsClient."""
 
-    def __init__(self, socket_path, prefix=None, timeout=None):
+    def __init__(
+        self, socket_path: str, prefix: str | None = None, timeout: float | None = None
+    ) -> None:
         """Create a new client."""
         self._socket_path = socket_path
         self._timeout = timeout
         self._prefix = prefix
         self._sock = None
 
-    def connect(self):
+    def connect(self) -> None:
         self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         self._sock.settimeout(self._timeout)
         self._sock.connect(self._socket_path)

--- a/statsd/client/timer.py
+++ b/statsd/client/timer.py
@@ -1,8 +1,23 @@
+from __future__ import annotations
+
 import functools
-from time import perf_counter as time_now
+from collections.abc import Callable, Sequence
+from time import perf_counter
+from types import TracebackType
+from typing import TYPE_CHECKING, TypeVar
+
+if TYPE_CHECKING:
+    from .base import StatsClientBase
+
+    R = TypeVar("R")
+    C = TypeVar("C", bound=StatsClientBase)
 
 
-def safe_wraps(wrapper, *args, **kwargs):
+def safe_wraps(
+    wrapper: Callable[..., R] | functools.partial[R],
+    *args: Sequence[str],
+    **kwargs: Sequence[str],
+) -> Callable[..., Callable[..., R]]:
     """Safely wraps partial functions."""
     while isinstance(wrapper, functools.partial):
         wrapper = wrapper.func
@@ -12,50 +27,55 @@ def safe_wraps(wrapper, *args, **kwargs):
 class Timer:
     """A context manager/decorator for statsd.timing()."""
 
-    def __init__(self, client, stat, rate=1):
+    def __init__(self, client: C, stat: str, rate: float = 1):
         self.client = client
         self.stat = stat
         self.rate = rate
-        self.ms = None
+        self.ms: float | None = None
         self._sent = False
-        self._start_time = None
+        self._start_time: float | None = None
 
-    def __call__(self, f):
+    def __call__(self, f: Callable[..., R]) -> Callable[..., R]:
         """Thread-safe timing function decorator."""
 
         @safe_wraps(f)
-        def _wrapped(*args, **kwargs):
-            start_time = time_now()
+        def _wrapped(*args: object, **kwargs: object) -> R:
+            start_time = perf_counter()
             try:
                 return f(*args, **kwargs)
             finally:
-                elapsed_time_ms = 1000.0 * (time_now() - start_time)
+                elapsed_time_ms = 1000.0 * (perf_counter() - start_time)
                 self.client.timing(self.stat, elapsed_time_ms, self.rate)
 
         return _wrapped
 
-    def __enter__(self):
+    def __enter__(self) -> Timer:
         return self.start()
 
-    def __exit__(self, typ, value, tb):
+    def __exit__(
+        self,
+        typ: type[BaseException] | None,
+        value: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
         self.stop()
 
-    def start(self):
+    def start(self) -> Timer:
         self.ms = None
         self._sent = False
-        self._start_time = time_now()
+        self._start_time = perf_counter()
         return self
 
-    def stop(self, send=True):
+    def stop(self, send: bool = True) -> Timer:
         if self._start_time is None:
             raise RuntimeError("Timer has not started.")
-        dt = time_now() - self._start_time
+        dt = perf_counter() - self._start_time
         self.ms = 1000.0 * dt  # Convert to milliseconds.
         if send:
             self.send()
         return self
 
-    def send(self):
+    def send(self) -> None:
         if self.ms is None:
             raise RuntimeError("No data recorded.")
         if self._sent:

--- a/statsd/client/udp.py
+++ b/statsd/client/udp.py
@@ -1,14 +1,16 @@
+from __future__ import annotations
+
 import socket
 
 from .base import PipelineBase, StatsClientBase
 
 
 class Pipeline(PipelineBase):
-    def __init__(self, client):
+    def __init__(self, client: StatsClient) -> None:
         super().__init__(client)
         self._maxudpsize = client._maxudpsize
 
-    def _send(self):
+    def _send(self, data: str | None = None) -> None:
         data = self._stats.popleft()
         while self._stats:
             # Use popleft to preserve the order of the stats.
@@ -25,30 +27,38 @@ class StatsClient(StatsClientBase):
     """A client for statsd."""
 
     def __init__(
-        self, host="localhost", port=8125, prefix=None, maxudpsize=512, ipv6=False
-    ):
+        self,
+        host: str = "localhost",
+        port: int = 8125,
+        prefix: str | None = None,
+        maxudpsize: int = 512,
+        ipv6: bool = False,
+    ) -> None:
         """Create a new client."""
         fam = socket.AF_INET6 if ipv6 else socket.AF_INET
         family, _, _, _, addr = socket.getaddrinfo(host, port, fam, socket.SOCK_DGRAM)[
             0
         ]
         self._addr = addr
-        self._sock = socket.socket(family, socket.SOCK_DGRAM)
+        self._sock: socket.socket | None = socket.socket(family, socket.SOCK_DGRAM)
         self._prefix = prefix
         self._maxudpsize = maxudpsize
 
-    def _send(self, data):
+    def _send(self, data: str | None) -> None:
         """Send data to statsd."""
-        try:
-            self._sock.sendto(data.encode("ascii"), self._addr)
-        except (OSError, RuntimeError):
-            # No time for love, Dr. Jones!
-            pass
+        if self._sock is None:
+            raise RuntimeError("Trying to send to closed socket")
+        if data is not None:
+            try:
+                self._sock.sendto(data.encode("ascii"), self._addr)
+            except (OSError, RuntimeError):
+                # No time for love, Dr. Jones!
+                pass
 
-    def close(self):
+    def close(self) -> None:
         if self._sock and hasattr(self._sock, "close"):
             self._sock.close()
         self._sock = None
 
-    def pipeline(self):
+    def pipeline(self) -> Pipeline:
         return Pipeline(self)

--- a/statsd/defaults/django.py
+++ b/statsd/defaults/django.py
@@ -1,4 +1,4 @@
-from django.conf import settings
+from django.conf import settings  # type: ignore[import]
 
 from statsd import defaults
 from statsd.client import StatsClient

--- a/tests/statsd_test.py
+++ b/tests/statsd_test.py
@@ -964,7 +964,7 @@ def test_tcp_timeout(mock_socket):
     test_timeout = 321
     cl = TCPStatsClient(timeout=test_timeout)
     cl.incr("foo")
-    cl._sock.settimeout.assert_called_once_with(test_timeout)
+    cl._sock.settimeout.assert_called_once_with(test_timeout)  # type: ignore[union-attr]
 
 
 @mock.patch.object(socket, "socket")
@@ -973,7 +973,7 @@ def test_unix_socket_timeout(mock_socket):
     test_timeout = 321
     cl = UnixSocketStatsClient(UNIX_SOCKET, timeout=test_timeout)
     cl.incr("foo")
-    cl._sock.settimeout.assert_called_once_with(test_timeout)
+    cl._sock.settimeout.assert_called_once_with(test_timeout)  # type: ignore[union-attr]
 
 
 @mock.patch.object(socket, "socket")


### PR DESCRIPTION
- Run `mypy` as part of CI linting

- Add type annotations to statsd (and tests)

    Functionally this should have no impact. I did have to add some `not
    None` checks on sockets and data, but without these checks
    `AttributeError`s would be raised anyway.

    I also updated some signatures of `_send` methods where some clients
    (e.g. the UDP one) didn't take a `data` arg since they tracked this
    internally. The signature changes was to just add a default as `None`
    for this `data` which may be a bit ambiguous (suggesting one _could_
    send `data` and expect some different behaviour) but since this is just
    the internal API I'm not so concerned.

- Add `mypy` config

    I've made the `tests` as relaxed as possible with the goal of:

    * Not having extra friction in worrying about typing when writing tests,
      while
    * Having some checks on the actual behaviour of the library's types
      (since `--check-untyped-defs` is still enabled and should check our
       calls)