### PR TITLE
Misc cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,8 +70,8 @@ jobs:
       - *attach_virtualenv
       - *load_virtualenv
       - run: flake8 statsd
-      - run: black --check --diff statsd
-      - run: isort --check-only --diff statsd
+      - run: black --check --diff statsd tests
+      - run: isort --check-only --diff statsd tests
 
 workflows:
   test-pythons:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal = 1
-
 [flake8]
 ignore =
     # E501 line too long (82 > 79 characters)

--- a/statsd/client/timer.py
+++ b/statsd/client/timer.py
@@ -1,12 +1,5 @@
 import functools
-
-# Use timer that's not susceptible to time of day adjustments.
-try:
-    # perf_counter is only present on Py3.3+
-    from time import perf_counter as time_now
-except ImportError:
-    # fall back to using time
-    from time import time as time_now
+from time import perf_counter as time_now
 
 
 def safe_wraps(wrapper, *args, **kwargs):


### PR DESCRIPTION
- Remove unused `setup.cfg` option

    Remove `bdist_wheel` section because[1]:

    > Only use this setting if your project does not have any C extensions
    and supports Python 2 and 3.

    which we no longer need, since this package doesn't support Python 2

    [1] https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#wheels

- CI: Run linters over `tests` as well as `statsd`

    Something I missed while extracting the tests

- Remove unnecessary import guard

    We don't need this since 5763d98e1c062c58a1fbf82f81c96c13e8326ece
