### PR TITLE
Build docs in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
       - checkout
       - *attach_virtualenv
       - *load_virtualenv
-      - run: flake8 statsd
+      - run: flake8 statsd tests
       - run: black --check --diff statsd tests
       - run: isort --check-only --diff statsd tests
       - run: mypy --show-error-codes statsd tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,18 @@ jobs:
       - run: isort --check-only --diff statsd tests
       - run: mypy --show-error-codes statsd tests
 
+  build-docs:
+    docker:
+      - image: cimg/python:3.10
+    steps:
+      - checkout
+      - *attach_virtualenv
+      - *load_virtualenv
+      - run:
+          name: Build docs
+          working_directory: ./docs
+          command: make html SPHINXOPTS='-W --keep-going'
+
 workflows:
   test-pythons:
     jobs:
@@ -88,5 +100,8 @@ workflows:
           requires:
             - build
       - lint:
+          requires:
+            - build
+      - build-docs:
           requires:
             - build

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -119,7 +119,7 @@ html_theme = 'default'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -84,6 +84,7 @@ Contents
    unix_socket.rst
    reference.rst
    contributing.rst
+   tags.rst
 
 
 Indices and tables

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ pytest>=6.2.5
 black ~= 22.0
 isort ~= 5.10
 mypy <= 1.0.0
+sphinx

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,5 @@
 [flake8]
+exclude = docs/conf.py
 ignore =
     # E501 line too long (82 > 79 characters)
     # because we just let 'black' handle this
@@ -6,9 +7,11 @@ ignore =
 
 [isort]
 profile = black
+skip = docs/conf.py
 
 [mypy]
 strict = True
+exclude = docs/.*\.py$
 
 [mypy-tests.*]
 disallow_untyped_calls = False


### PR DESCRIPTION
- CI: Ensure `flake8` is run over tests

- Add some linter rules to ignore `docs`

    The python file at `docs/conf.py` was just generated from `sphinx` and
    should be fairly static, so I'm not to worried about linting this (it
    might be nice if it could be configured in a static file)

- Fix warnings when building docs

    Fix warning:

    > WARNING: html_static_path entry '_static' does not exist

    Fix warning:

    > checking consistency... /home/circleci/project/docs/tags.rst: WARNING:
    document isn't included in any toctree

    I guess this was just an oversight when adding
    db576ab5f5a13b46e990f0fbd383e5b0af96da42

- Build docs during CI

    This is to ensure these docs can always build and that they don't get
    horribly out of date with the code.