### PR TITLE
Deploy docs from ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,9 +86,35 @@ jobs:
           working_directory: ./docs
           command: make html SPHINXOPTS='-W --keep-going'
       - persist_to_workspace:
-          root: ./docs
+          root: ./docs/_build
           paths:
-            - _build
+            - html
+
+  deploy-gh-pages:
+    docker:
+      - image: cimg/base:current
+    steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "ce:96:37:12:7d:fc:f8:98:36:18:b0:0d:d3:36:d5:b6"
+      - checkout
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: Deploy docs
+          command: |
+            git checkout gh-pages
+            # remove all old docs files
+            git rm -r -- ':(exclude).nojekyll'
+            # and replace with the new ones
+            (shopt -s dotglob; cp --recursive /tmp/workspace/html/* .)
+
+            git config user.name "CircleCI"
+            git config user.email "circleci@site.invalid"
+
+            git add .
+            git commit --message "Deploy docs for: $CIRCLE_SHA1"
+            git push origin HEAD
 
 workflows:
   test-pythons:
@@ -109,3 +135,11 @@ workflows:
       - build-docs:
           requires:
             - build
+      - deploy-gh-pages:
+          requires:
+            - build-docs
+          filters:
+            branches:
+              only:
+                - master
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,10 @@ jobs:
           name: Build docs
           working_directory: ./docs
           command: make html SPHINXOPTS='-W --keep-going'
+      - persist_to_workspace:
+          root: ./docs
+          paths:
+            - _build
 
 workflows:
   test-pythons:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,15 @@ import sys, os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.todo', 'sphinx.ext.mathjax', 'sphinx.ext.ifconfig', 'sphinx.ext.viewcode']
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.doctest',
+    'sphinx.ext.todo',
+    'sphinx.ext.mathjax',
+    'sphinx.ext.ifconfig',
+    'sphinx.ext.viewcode',
+    'sphinx_rtd_theme',
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -90,7 +98,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,7 @@ pytest>=6.2.5
 black ~= 22.0
 isort ~= 5.10
 mypy <= 1.0.0
+
+# for building docs
 sphinx
+sphinx_rtd_theme


### PR DESCRIPTION
- Add Sphinx Read-The-Docs theme

    Add this as a dev dependency (and add some whitespace to split up docs
    vs. lint dependencies) and configure Sphinx to use this extension.

- CI: Store built docs

    Store these to be used in a separate step (coming soon) to deploy the
    docs on master.

- CI: Add step to deploy docs from

    This step will be run each time on master and uses a new branch
    `gh-pages` which contains a subtree containing just the built docs.

    `git` is configured with some placeholder details, and the commit for
    each deploy just gives the SHA on master the docs were built from.

    The docs should then be available at [1]

    [1] https://matthewhughes934.github.io/pystatsd/