### PR TITLE
Packaging improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ commands:
           key: pip-cache-v0-{{ checksum "pip-cache-key.txt" }}
       - run:
           name: Install requirements
-          command: pip install --requirement requirements-dev.txt --cache-dir .cache/pip
+          command: pip install --requirement requirements-dev.txt --cache-dir .cache/pip .
       - save_cache:
           key: pip-cache-v0-{{ checksum "pip-cache-key.txt" }}
           paths: .cache/pip

--- a/README.rst
+++ b/README.rst
@@ -5,9 +5,9 @@ A Python statsd client
 statsd_ is a friendly front-end to Graphite_. This is a Python client
 for the statsd daemon.
 
-.. image:: https://travis-ci.org/jsocol/pystatsd.png?branch=master
-   :target: https://travis-ci.org/jsocol/pystatsd
-   :alt: Travis-CI build status
+.. image:: https://dl.circleci.com/status-badge/img/gh/matthewhughes934/pystatsd/tree/master.svg?style=svg
+   :target: https://dl.circleci.com/status-badge/redirect/gh/matthewhughes934/pystatsd/tree/master
+   :alt: CircleCI build status
 
 .. image:: https://img.shields.io/pypi/v/statsd.svg
    :target: https://pypi.python.org/pypi/statsd/
@@ -21,10 +21,10 @@ for the statsd daemon.
    :target: https://pypi.python.org/pypi/statsd/
    :alt: Wheel Status
 
-:Code:          https://github.com/jsocol/pystatsd
+:Code:          https://github.com/matthewhughes934/pystatsd
 :License:       MIT; see LICENSE file
 :Issues:        https://github.com/jsocol/pystatsd/issues
-:Documentation: https://statsd.readthedocs.io/
+:Documentation: https://matthewhughes934.github.io/pystatsd/
 
 Quickly, to use:
 
@@ -55,11 +55,11 @@ You can install from PyPI::
 
 Or GitHub::
 
-    $ pip install -e git+https://github.com/jsocol/pystatsd#egg=statsd
+    $ pip install -e https://github.com/matthewhughes934/pystatsd#egg=statsd
 
 Or from source::
 
-    $ git clone https://github.com/jsocol/pystatsd
+    $ git clone https://github.com/matthewhughes934/pystatsd
     $ cd pystatsd
     $ python setup.py install
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,22 +9,26 @@ Welcome to Python StatsD's documentation!
 statsd_ is a friendly front-end to Graphite_. This is a Python client
 for the statsd daemon.
 
-.. image:: https://travis-ci.org/jsocol/pystatsd.png?branch=master
-   :target: https://travis-ci.org/jsocol/pystatsd
-   :alt: Travis-CI build status
+.. image:: https://dl.circleci.com/status-badge/img/gh/matthewhughes934/pystatsd/tree/master.svg?style=svg
+   :target: https://dl.circleci.com/status-badge/redirect/gh/matthewhughes934/pystatsd/tree/master
+   :alt: CircleCI build status
 
-.. image:: https://pypip.in/v/statsd/badge.png
+.. image:: https://img.shields.io/pypi/v/statsd.svg
    :target: https://pypi.python.org/pypi/statsd/
    :alt: Latest release
 
-.. image:: https://pypip.in/d/statsd/badge.png
+.. image:: https://img.shields.io/pypi/pyversions/statsd.svg
    :target: https://pypi.python.org/pypi/statsd/
-   :alt: Downloads
+   :alt: Supported Python versions
 
-:Code:          https://github.com/jsocol/pystatsd
+.. image:: https://img.shields.io/pypi/wheel/statsd.svg
+   :target: https://pypi.python.org/pypi/statsd/
+   :alt: Wheel Status
+
+:Code:          https://github.com/matthewhughes934/pystatsd
 :License:       MIT; see LICENSE file
 :Issues:        https://github.com/jsocol/pystatsd/issues
-:Documentation: https://statsd.readthedocs.io/
+:Documentation: https://matthewhughes934.github.io/pystatsd/
 
 Quickly, to use:
 
@@ -59,13 +63,13 @@ Or GitHub:
 
 .. code-block:: bash
 
-    $ pip install -e git+https://github.com/jsocol/pystatsd#egg=statsd
+    $ pip install -e git+https://github.com/matthewhughes934/pystatsd#egg=statsd
 
 Or from source:
 
 .. code-block:: bash
 
-    $ git clone https://github.com/jsocol/pystatsd
+    $ git clone https://github.com/matthewhughes934/pystatsd
     $ cd statsd
     $ python setup.py install
 

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     package_data={'': ['README.rst'], "statsd": ["py.typed"]},
     test_suite='nose.collector',
     python_requires='>=3.7',
+    install_requires='importlib-metadata;python_version<"3.8"',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     license='MIT',
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
-    package_data={'': ['README.rst']},
+    package_data={'': ['README.rst'], "statsd": ["py.typed"]},
     test_suite='nose.collector',
     python_requires='>=3.7',
     classifiers=[

--- a/statsd/__init__.py
+++ b/statsd/__init__.py
@@ -1,5 +1,11 @@
+import sys
+
 from .client import StatsClient, TCPStatsClient, UnixSocketStatsClient
 
-VERSION = (3, 2, 1)
-__version__ = ".".join(map(str, VERSION))
+if sys.version_info >= (3, 8):  # pragma: >=3.8 cover
+    import importlib.metadata as importlib_metadata
+else:  # pragma: <3.8 cover
+    import importlib_metadata
+
+__version__ = version = importlib_metadata.version(__name__)
 __all__ = ["StatsClient", "TCPStatsClient", "UnixSocketStatsClient"]


### PR DESCRIPTION
- Update docs to reference fork rather than origin

- Add PEP 561 packaging information

    So types can actually be used by users

- Fetch version via `importlib.metadata`

    This is to avoid repeating ourselves and potentially making errors (like
    there is currently, where the package version != the version exposed as
    `statsd.__version__`)