### PR TITLE
Test improvements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,3 +18,6 @@ disallow_untyped_calls = False
 disallow_untyped_defs = False
 warn_return_any = False
 strict_equality = False
+
+[tool:pytest]
+filterwarnings = error

--- a/tests/statsd_test.py
+++ b/tests/statsd_test.py
@@ -35,6 +35,8 @@ def _udp_client(prefix=None, addr=None, port=None, ipv6=False):
     if not port:
         port = ADDR[1]
     sc = StatsClient(host=addr, port=port, prefix=prefix, ipv6=ipv6)
+    # close socket to avoid a ResourceWarning
+    sc.close()
     sc._sock = mock.Mock()
     return sc
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,pypy,py34,py35,py36,py37
+envlist = py37,py38,py39,py310
 
 [testenv]
 deps=


### PR DESCRIPTION
- Add supported Python versions to tox.ini

- Promote warnings->errors under testing

    This required fixing a `ResourceWarning` when we create a `StatsClient`
    but don't close the socket.