### PR TITLE
Tweak intergration tests

### DIFF
--- a/statsd/client/base.py
+++ b/statsd/client/base.py
@@ -40,11 +40,11 @@ class StatsClientBase:
             delta = delta.total_seconds() * 1000.0
         self._send_stat(stat, "%0.6f|ms" % delta, rate)
 
-    def incr(self, stat: str, count: int = 1, rate: float = 1) -> None:
+    def incr(self, stat: str, count: float = 1, rate: float = 1) -> None:
         """Increment a stat by `count`."""
         self._send_stat(stat, "%s|c" % count, rate)
 
-    def decr(self, stat: str, count: int = 1, rate: float = 1) -> None:
+    def decr(self, stat: str, count: float = 1, rate: float = 1) -> None:
         """Decrement a stat by `count`."""
         self.incr(stat, -count, rate)
 

--- a/tests/statsd_integration_test.py
+++ b/tests/statsd_integration_test.py
@@ -42,12 +42,10 @@ class UDPServer(threading.Thread):
     def __init__(
         self,
         sock: socket.socket,
-        host: str,
-        port: int,
+        addr: tuple[str, int],
     ) -> None:
         self._sock = sock
-        self._host = host
-        self._port = port
+        self._addr = addr
         self.received: list[str] = []
         self.listening = False
 
@@ -55,7 +53,7 @@ class UDPServer(threading.Thread):
 
     def run(self) -> None:
         with self._sock as sock:
-            sock.bind((self._host, self._port))
+            sock.bind(self._addr)
             self.listening = True
 
             while True:
@@ -101,7 +99,7 @@ class StreamServer(threading.Thread):
 def test_incr_udp(port):
     host = "127.0.0.1"
     server_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    server = UDPServer(server_socket, host, port)
+    server = UDPServer(server_socket, (host, port))
     server.start()
 
     client = StatsClient(host=host, port=port)

--- a/tests/statsd_integration_test.py
+++ b/tests/statsd_integration_test.py
@@ -140,3 +140,41 @@ def test_incr(client_server_pair):
     server.join()
 
     assert server.received == ["foo:1|c", "foo:10|c", "foo:10|c|@0.5"]
+
+
+@mock.patch.object(random, "random", lambda: -1)
+def test_decr(client_server_pair):
+    client, server = client_server_pair
+    server.start()
+
+    while not server.listening:
+        time.sleep(0.01)
+
+    with terminating_client(client):
+        client.decr("foo")
+        client.decr("foo", 10)
+        client.decr("foo", 10, rate=0.5)
+
+    client.close()
+    server.join()
+
+    assert server.received == ["foo:-1|c", "foo:-10|c", "foo:-10|c|@0.5"]
+
+
+@mock.patch.object(random, "random", lambda: -1)
+def test_guage(client_server_pair):
+    client, server = client_server_pair
+    server.start()
+
+    while not server.listening:
+        time.sleep(0.01)
+
+    with terminating_client(client):
+        client.gauge("foo", 30)
+        client.gauge("foo", 1.2)
+        client.gauge("foo", 70, rate=0.5)
+
+    client.close()
+    server.join()
+
+    assert server.received == ["foo:30|g", "foo:1.2|g", "foo:70|g|@0.5"]

--- a/tests/statsd_integration_test.py
+++ b/tests/statsd_integration_test.py
@@ -134,12 +134,13 @@ def test_incr(client_server_pair):
     with terminating_client(client):
         client.incr("foo")
         client.incr("foo", 10)
+        client.incr("foo", 1.2)
         client.incr("foo", 10, rate=0.5)
 
     client.close()
     server.join()
 
-    assert server.received == ["foo:1|c", "foo:10|c", "foo:10|c|@0.5"]
+    assert server.received == ["foo:1|c", "foo:10|c", "foo:1.2|c", "foo:10|c|@0.5"]
 
 
 @mock.patch.object(random, "random", lambda: -1)
@@ -153,12 +154,13 @@ def test_decr(client_server_pair):
     with terminating_client(client):
         client.decr("foo")
         client.decr("foo", 10)
+        client.decr("foo", 1.2)
         client.decr("foo", 10, rate=0.5)
 
     client.close()
     server.join()
 
-    assert server.received == ["foo:-1|c", "foo:-10|c", "foo:-10|c|@0.5"]
+    assert server.received == ["foo:-1|c", "foo:-10|c", "foo:-1.2|c", "foo:-10|c|@0.5"]
 
 
 @mock.patch.object(random, "random", lambda: -1)


### PR DESCRIPTION
- Use same init args for UDP and Stream test servers

- Simplify integration tests

    Use fixtures to build client/server pairs that can be then used to
    parametrize a single test (e.g. testing `incr`)

    Also ensure Unix socket test isn't run without Unix socket support.

- Add integration tests for `decr` and `gauge`

- Update typing for `incr`/`decr`

    Allow the count for these functions to be `float`. This was inspired by
    an existing test that used such a value, I also tested via a run of

        $ docker run -d \
         --name graphite \
         --restart=always \
         -p 80:80 \
         -p 2003-2004:2003-2004 \
         -p 2023-2024:2023-2024 \
         -p 8125:8125/udp \
         -p 8126:8126 \
         graphiteapp/graphite-statsd
       $ echo -n "example:5.5|c" | nc -w 1 -u 127.0.0.1 8125;

    The dashboard at http://localhost/dashboard then happily displayed the
    value 5.5 (I'm assuming there's not some incompatibility with `statsd`
    in the pipeline)